### PR TITLE
Fixed #87 Fatal PHP Error in EasyDigitalDownloads

### DIFF
--- a/classes/Pronamic/EasyDigitalDownloads/PaymentData.php
+++ b/classes/Pronamic/EasyDigitalDownloads/PaymentData.php
@@ -14,7 +14,7 @@ class Pronamic_EasyDigitalDownloads_PaymentData extends Pronamic_WP_Pay_PaymentD
      *
      * @var int
      */
-    private $payment_id;
+    public $payment_id;
 
     /**
      * Payment data


### PR DESCRIPTION
This was the error I encountered:

PHP Fatal error: Access level to Pronamic_EasyDigitalDownloads_PaymentData::$payment_id must be public
(as in class Pronamic_WP_Pay_PaymentData) in /wp-content/plugins/pronamic-ideal/classes/Pronamic/EasyDigitalDownloads/PaymentData.php
on line 11

After looking into the AbstractPaymentData.php file it seems the error
message is hitting the nail on the head: the payment_id is public in the
abstract class, but made private in the extended class which seems to
cause this issue. I'm hesitant in just making the payment_id public in
the extended class as I cannot oversee if this may cause any unwanted
side effects, but so far this has solved the issue for me and allowed
the payment to go through.
